### PR TITLE
Rounding PowerUp amount to 3 decimal places

### DIFF
--- a/app/components/Vesting/PowerUpPrompt.js
+++ b/app/components/Vesting/PowerUpPrompt.js
@@ -65,13 +65,13 @@ class PowerUpPrompt extends Component {
   }
 
   handleOnChange = (value) => {
-    const hiveAmount = parseFloat(value);
+    const hiveAmount = Number(parseFloat(value).toFixed(3));
     // const props = this.props.hive.props;
     this.setState({ hiveAmount });
   }
 
   handleOnChangeComplete = (value) => {
-    const hiveAmount = parseFloat(value);
+    const hiveAmount = Number(parseFloat(value).toFixed(3));
     // const props = this.props.hive.props;
     this.setState({ hiveAmount });
   }


### PR DESCRIPTION
In the 'PowerUp' prompt, there is a slider to select the amount of HIVE to power up.

That slider can give values that have more than 3 decimal places (e.g. 1.00001), leading to the following error when attempting to use it:

![image](https://user-images.githubusercontent.com/9859171/77221899-4da9b000-6b0b-11ea-93cd-6b45a8dd9312.png)

I solved it by adding two lines of code in the PowerUpPrompt.js file in handleOnChange and handleOnChangeComplete.

Previously, the lines were:

`const hiveAmount = parseFloat(value)`

which will take the string literal value out of the slider and parse it to a float. I guarded against slider values with too many decimal places by changing that line into the following:

`const hiveAmount = Number(parseFloat(value).toFixed(3));`
